### PR TITLE
Fallback to Node 7.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "A bot for the DDFC OVA Discord server, because Enra's bots are buggy.\r TODO: Literally everything.",
   "engines": {
-    "node": "8.1.x"
+    "node": "7.6.x"
   },
   "dependencies":
   {


### PR DESCRIPTION
Due to outstanding issues in NPM v5, I recommend falling back to Node 7.6 which has almost of the same performance as Node 8.